### PR TITLE
Augment types for safety; Use viewport's initial scale

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,38 @@
+import * as PIXI from 'pixi.js';
+import GestureEvent from './gesture-event';
+
+declare global {
+  interface GestureEventMap extends HTMLElementEventMap {
+    gesturestart: GestureEvent;
+    gesturechange: GestureEvent;
+    gestureend: GestureEvent;
+  }
+
+  interface HTMLElement {
+    addEventListener<K extends keyof GestureEventMap>(
+      eventName: K,
+      listener: (
+        this: HTMLElement,
+        ev: GestureEventMap[K],
+        options?: boolean | AddEventListenerOptions
+      ) => any
+    ): void;
+    removeEventListener<K extends keyof GestureEventMap>(
+      eventName: K,
+      listener: (
+        this: HTMLElement,
+        ev: GestureEventMap[K],
+        options?: boolean | AddEventListenerOptions
+      ) => any
+    ): void;
+  }
+}
+
+declare module 'pixi-viewport' {
+  interface Viewport {
+    input: {
+      getPointerPosition(event: GestureEvent): PIXI.Point;
+    }
+  }
+}
+

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -32,7 +32,6 @@ declare module 'pixi-viewport' {
   interface Viewport {
     input: {
       getPointerPosition(event: GestureEvent): PIXI.Point;
-    }
+    };
   }
 }
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import './global';
 import { Viewport } from 'pixi-viewport';
 import { Point } from 'pixi.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ class PinchPlugin extends BasePlugin {
       this.onGestureEnd as any
     );
 
-    this.initialScale = 1;
+    this.initialScale = this.viewport.scale.x;
   }
 
   public destroy(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import './global';
 import { Viewport } from 'pixi-viewport';
 import { Point } from 'pixi.js';
 
@@ -20,43 +21,25 @@ class PinchPlugin extends BasePlugin {
     this.viewport = options.viewport;
     this.listenerNode = options.listenerNode || document.body;
 
-    // A bit of silly type coercion here to override TypeScript, which is smart
-    // enough to know that both the event names and objects are totally invalid.
-    this.listenerNode.addEventListener(
-      'gesturestart' as any,
-      this.onGestureStart as any
-    );
-    this.listenerNode.addEventListener(
-      'gesturechange' as any,
-      this.onGestureChange as any
-    );
-    this.listenerNode.addEventListener(
-      'gestureend' as any,
-      this.onGestureEnd as any
-    );
+    this.listenerNode.addEventListener('gesturestart', this.onGestureStart);
+    this.listenerNode.addEventListener('gesturechange', this.onGestureChange);
+    this.listenerNode.addEventListener('gestureend', this.onGestureEnd);
 
     this.initialScale = this.viewport.scale.x;
   }
 
   public destroy(): void {
+    this.listenerNode.removeEventListener('gesturestart', this.onGestureStart);
     this.listenerNode.removeEventListener(
-      'gesturestart' as any,
-      this.onGestureStart as any
+      'gesturechange',
+      this.onGestureChange
     );
-    this.listenerNode.removeEventListener(
-      'gesturechange' as any,
-      this.onGestureChange as any
-    );
-    this.listenerNode.removeEventListener(
-      'gestureend' as any,
-      this.onGestureEnd as any
-    );
+    this.listenerNode.removeEventListener('gestureend', this.onGestureEnd);
   }
 
   private onGestureStart = (event: GestureEvent): void => {
     this.initialScale = this.viewport.scale.x;
-    const initialGlobalPosition: PIXI.Point = (this
-      .viewport as any).input.getPointerPosition(event);
+    const initialGlobalPosition = this.viewport.input.getPointerPosition(event);
     this.initialLocalPosition = this.viewport.toLocal(initialGlobalPosition);
   };
 


### PR DESCRIPTION
On the off chance that this plugin is added later than the viewport is initialized, or if the viewport is initialized with a scale other than `1`, it seems safer to initialize our own scale as `this.viewport.scale`.

Also learned a bit about augmenting types, so through together some type augmentations in `global.d.ts` to reduce the amount of `any`s here.